### PR TITLE
Fix tiny typo in readme (lastest -> latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You might want to directly use winres as a library too: [github.com/tc-hib/winre
 To install the go-winres command, run:
 
 ```shell
-go install github.com/tc-hib/go-winres@lastest
+go install github.com/tc-hib/go-winres@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Hey there, just notice there was a tiny typo in the readme when trying to go get the library.