### PR TITLE
Provide more verbose error on failed git tag resolution

### DIFF
--- a/main.go
+++ b/main.go
@@ -586,7 +586,7 @@ func getGitTag() (string, error) {
 	cmd.Stdout = &w
 	err := cmd.Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed resolving git tag: %w", err)
 	}
 	return strings.TrimSpace(w.String()), nil
 }


### PR DESCRIPTION
The error when doing this in a shallow clone is simply "exit 128",
which makes it very difficult to determine that the problem is the lack
of git tag data. This change just makes that error more clear.