### PR TITLE
fix(init subCommand): permission denied when on Unix platform

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,19 +209,19 @@ func main() {
 }
 
 func cmdInit(_ *cli.Context) error {
-	err := os.MkdirAll(filepath.Dir(defaultJSONFile), 0666)
+	err := os.MkdirAll(filepath.Dir(defaultJSONFile), 0755)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(defaultJSONFile, []byte(initJSON), 0666)
+	err = ioutil.WriteFile(defaultJSONFile, []byte(initJSON), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(defaultIconFile, initIcon, 0666)
+	err = ioutil.WriteFile(defaultIconFile, initIcon, 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(defaultIcon16File, initIcon16, 0666)
+	err = ioutil.WriteFile(defaultIcon16File, initIcon16, 0644)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func cmdExtract(ctx *cli.Context) error {
 	f.Close()
 
 	out := ctx.String(flagOutputDir)
-	err = os.MkdirAll(out, 0666)
+	err = os.MkdirAll(out, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I tried to run `go-winres init` on my Mac, however, it just kept telling me:

```
❯ go-winres init
2022/11/10 15:34:29 open winres/winres.json: permission denied
❯ ls -alh .
total 120
drwxr-xr-x  18 kmahyyg  staff   576B Nov 10 15:25 .
drwxr-xr-x   7 kmahyyg  staff   224B Oct 15 19:47 ..
-rw-r--r--@  1 kmahyyg  staff   6.0K Oct 27 12:50 .DS_Store
drwxr-xr-x  16 kmahyyg  staff   512B Nov 10 15:34 .git
-rw-r--r--   1 kmahyyg  staff   4.2K Oct 28 20:03 .gitignore
-rw-r--r--   1 kmahyyg  staff   154B Oct 31 14:16 .gitmodules
drwxr-xr-x   8 kmahyyg  staff   256B Nov 10 15:29 .idea
<REDACTED HERE>
drw-r--r--   5 kmahyyg  staff   160B Nov 10 15:34 winres
```

Then I just realized what went wrong. On unix platform, folder default permission should be 755, files should have 644. (You will not like any others write your own files, right?) Since Windows doesn't use the same method for access control, 755 and 644 will work on Windows platform too.

So this PR will allow more user to run this develop their apps on MacOS / Linux without effecting any existing users.

