### PR TITLE
return 0.0.0.0 if no tag found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,11 @@ require (
 	github.com/tc-hib/winres v0.2.1
 	github.com/urfave/cli/v2 v2.25.7
 )
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/image v0.12.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
@@ -44,5 +43,3 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -586,6 +586,10 @@ func getGitTag() (string, error) {
 	cmd.Stdout = &w
 	err := cmd.Run()
 	if err != nil {
+		// git describe --tags returns exit code 128 if none found.
+		if cmd.ProcessState.ExitCode() == 128 {
+			return "0.0.0.0", nil
+		}
 		return "", fmt.Errorf("failed resolving git tag: %w", err)
 	}
 	return strings.TrimSpace(w.String()), nil


### PR DESCRIPTION
## Description

The git-tag value means the current tag will be retrieved from `git describe --tags` and add it to the properties of the executable: https://github.com/tc-hib/go-winres#automatic-version-from-git This does not work if the current working repository has no tags in its history, such as my fork of this repo.

Instead use `git describe --tags --always` to always return a value from `git describe` - defaulting to the latest commit if no tags found: https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---always

Also, updates go.mod and go.sum

### Testing

`go test ./...`

### Context

In cmd/finch/main_windows.go, we are calling go-winres make  with flags set to git-tag: 

https://github.com/runfinch/finch/blob/76adf59588b1455a535f389eb4c714e1b9daede3/cmd/finch/main_windows.go#L6
```
//go:generate go-winres make --file-version=git-tag --product-version=git-tag --arch amd64 --in ../../winres/winres.json
```

Building is failing if the build occurs in a repository with no local tags. It’s only after I have my upstream remote set to the main finch repo and run `git fetch upstream --tags` that I can successfully build finch.

